### PR TITLE
Use plutil instead of defaults to read plist

### DIFF
--- a/Applanga.framework/update-settingsfile.sh
+++ b/Applanga.framework/update-settingsfile.sh
@@ -22,7 +22,7 @@ get_script_dir () {
 get_script_dir
 
 echo "Applanga SDK Path: $APPLANGA_FRAMEWORK_DIR"
-APPLANGA_FRAMEWORK_BUNDLEID=$(defaults read "$APPLANGA_FRAMEWORK_DIR/Info" CFBundleShortVersionString)
+APPLANGA_FRAMEWORK_BUNDLEID=$(plutil -extract CFBundleShortVersionString xml1 -o - $APPLANGA_FRAMEWORK_DIR/Info.plist | sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p")
 echo "Applanga SDK Version: $APPLANGA_FRAMEWORK_BUNDLEID"
 
 APPLANGA_DOWNLOAD_SCRIPTPATH=/tmp/Applanga-Scripts/${APPLANGA_FRAMEWORK_BUNDLEID}/settingsfile_update.py


### PR DESCRIPTION
I'm running Mac OS Catalina 10.15.1, and it seems that `defaults` no longer reads plist files from a filepath. There is a warning in the `man defaults` page:
> WARNING: The defaults command will be changed in an upcoming major release to only operate on
               preferences domains. General plist manipulation utilities will be folded into a different
               command-line program.

To get around this, I replaced it with `plutil` instead. `Plistbuddy` could also work here.